### PR TITLE
Fix import warnings and improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,4 @@ git clone https://github.com/YOUR_USERNAME/retirement-planner.git
 cd retirement-planner
 pip install -r requirements.txt
 streamlit run retirement_planner.py
+```

--- a/retirement_planner.py
+++ b/retirement_planner.py
@@ -90,69 +90,76 @@ def convert_plot_to_png(fig):
     buf.seek(0)
     return buf
 
-st.title("Retirement Planner")
+def main():
+    st.title("Retirement Planner")
 
-# Inputs
-col1, col2 = st.columns(2)
-with col1:
-    current_age = st.number_input("Your Current Age", min_value=18, max_value=100, value=35)
-    retirement_age = st.number_input("Retirement Age (optional)", min_value=18, max_value=100, value=65)
-    target_fund = st.number_input("Target Retirement Fund ($, optional)", min_value=0.0, value=1000000.0)
-with col2:
-    annual_growth = st.number_input("Expected Annual Growth (%)", min_value=0.0, value=7.0)
-    annual_inflation = st.number_input("Expected Annual Inflation (%)", min_value=0.0, value=2.5)
-    years = st.slider("Years to Simulate", min_value=1, max_value=70, value=50)
+    # Inputs
+    col1, col2 = st.columns(2)
+    with col1:
+        current_age = st.number_input("Your Current Age", min_value=18, max_value=100, value=35)
+        retirement_age = st.number_input("Retirement Age (optional)", min_value=18, max_value=100, value=65)
+        target_fund = st.number_input("Target Retirement Fund ($, optional)", min_value=0.0, value=1000000.0)
+    with col2:
+        annual_growth = st.number_input("Expected Annual Growth (%)", min_value=0.0, value=7.0)
+        annual_inflation = st.number_input("Expected Annual Inflation (%)", min_value=0.0, value=2.5)
+        years = st.slider("Years to Simulate", min_value=1, max_value=70, value=50)
 
-monthly_contribution = st.number_input("Monthly Contribution ($)", min_value=0.0, value=1000.0)
-monthly_withdrawal = st.number_input("Monthly Withdrawal After Retirement ($)", min_value=0.0, value=4000.0)
-inflation_adjusted_withdrawals = st.checkbox("Inflation-adjusted withdrawals?", value=True)
+    monthly_contribution = st.number_input("Monthly Contribution ($)", min_value=0.0, value=1000.0)
+    monthly_withdrawal = st.number_input("Monthly Withdrawal After Retirement ($)", min_value=0.0, value=4000.0)
+    inflation_adjusted_withdrawals = st.checkbox("Inflation-adjusted withdrawals?", value=True)
 
-# Lump sum contributions
-st.subheader("Optional Lump Sum Contributions")
-lump_years = st.text_input("Years and Amounts (format: year1:amount1, year2:amount2)", value="5:20000, 10:30000")
-lump_sums = {}
-try:
-    for pair in lump_years.split(","):
-        if ":" in pair:
-            y, a = pair.split(":")
-            lump_sums[int(y.strip()) * 12] = float(a.strip())
-except:
-    st.warning("Invalid lump sum format. Use format like '5:20000, 10:30000'")
+    # Lump sum contributions
+    st.subheader("Optional Lump Sum Contributions")
+    lump_years = st.text_input("Years and Amounts (format: year1:amount1, year2:amount2)", value="5:20000, 10:30000")
+    lump_sums = {}
+    try:
+        for pair in lump_years.split(","):
+            if ":" in pair:
+                y, a = pair.split(":")
+                lump_sums[int(y.strip()) * 12] = float(a.strip())
+    except Exception:
+        st.warning("Invalid lump sum format. Use format like '5:20000, 10:30000'")
 
-if st.button("Calculate Retirement Plan"):
-    df = calculate_retirement_plan(
-        current_age=current_age,
-        retirement_age=retirement_age,
-        target_fund=target_fund,
-        annual_growth=annual_growth,
-        annual_inflation=annual_inflation,
-        monthly_contribution=monthly_contribution,
-        monthly_withdrawal=monthly_withdrawal,
-        lump_sums=lump_sums,
-        years=years,
-        inflation_adjusted_withdrawals=inflation_adjusted_withdrawals
-    )
+    if st.button("Calculate Retirement Plan"):
+        df = calculate_retirement_plan(
+            current_age=current_age,
+            retirement_age=retirement_age,
+            target_fund=target_fund,
+            annual_growth=annual_growth,
+            annual_inflation=annual_inflation,
+            monthly_contribution=monthly_contribution,
+            monthly_withdrawal=monthly_withdrawal,
+            lump_sums=lump_sums,
+            years=years,
+            inflation_adjusted_withdrawals=inflation_adjusted_withdrawals
+        )
 
-    st.subheader("Progress Toward Retirement Goal")
-    if target_fund > 0:
-        reached = df[df['Reached Goal']]
-        if not reached.empty:
-            first_hit = reached.iloc[0]
-            months_to_goal = int(first_hit['Month'])
-            projected_date = datetime.today() + timedelta(days=months_to_goal * 30)
-            st.success(f"Goal of ${target_fund:,.0f} will be reached in {months_to_goal // 12} years and {months_to_goal % 12} months.")
-            st.write(f"Projected date: **{projected_date.strftime('%B %Y')}**")
+        st.subheader("Progress Toward Retirement Goal")
+        if target_fund > 0:
+            reached = df[df['Reached Goal']]
+            if not reached.empty:
+                first_hit = reached.iloc[0]
+                months_to_goal = int(first_hit['Month'])
+                projected_date = datetime.today() + timedelta(days=months_to_goal * 30)
+                st.success(
+                    f"Goal of ${target_fund:,.0f} will be reached in {months_to_goal // 12} years and {months_to_goal % 12} months."
+                )
+                st.write(f"Projected date: **{projected_date.strftime('%B %Y')}**")
+            else:
+                st.warning("Goal not reached in the given timeframe.")
         else:
-            st.warning("Goal not reached in the given timeframe.")
-    else:
-        st.info(f"Plan simulates retirement at age {retirement_age}.")
+            st.info(f"Plan simulates retirement at age {retirement_age}.")
 
-    fig1 = plot_growth(df)
-    st.pyplot(fig1)
+        fig1 = plot_growth(df)
+        st.pyplot(fig1)
 
-    fig2 = plot_progress_vs_contribution(df)
-    st.pyplot(fig2)
+        fig2 = plot_progress_vs_contribution(df)
+        st.pyplot(fig2)
 
-    st.download_button("Download Data as CSV", convert_df_to_csv(df), "retirement_data.csv", "text/csv")
-    st.download_button("Download Growth Chart", convert_plot_to_png(fig1), "retirement_growth.png", "image/png")
-    st.download_button("Download Progress Chart", convert_plot_to_png(fig2), "contribution_vs_value.png", "image/png")
+        st.download_button("Download Data as CSV", convert_df_to_csv(df), "retirement_data.csv", "text/csv")
+        st.download_button("Download Growth Chart", convert_plot_to_png(fig1), "retirement_growth.png", "image/png")
+        st.download_button("Download Progress Chart", convert_plot_to_png(fig2), "contribution_vs_value.png", "image/png")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- close markdown code fence in README
- wrap Streamlit UI in a `main()` function
- guard execution with `if __name__ == "__main__"`

## Testing
- `python -m py_compile retirement_planner.py`
- `python - <<'PY'
import retirement_planner as r
print('done importing')
print('months', r.calculate_retirement_plan(30,60,1000000,7,2.5,1000,4000,{},50,True).shape[0])
PY`

------
https://chatgpt.com/codex/tasks/task_e_6841c1a07edc83228e23d9f46415c7cb